### PR TITLE
Remove redundant call according to IDEA inspection

### DIFF
--- a/polling-app-server/src/main/java/com/example/polls/security/JwtAuthenticationFilter.java
+++ b/polling-app-server/src/main/java/com/example/polls/security/JwtAuthenticationFilter.java
@@ -58,7 +58,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private String getJwtFromRequest(HttpServletRequest request) {
         String bearerToken = request.getHeader("Authorization");
         if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
-            return bearerToken.substring(7, bearerToken.length());
+            return bearerToken.substring(7);
         }
         return null;
     }


### PR DESCRIPTION
According to IDEA inspection
```
Call to 'bearerToken.length()' is redundant 
```

And Java doc of **substring(int)** can be used for this purpose.

```
/**
     * Returns a string that is a substring of this string. The
     * substring begins with the character at the specified index and
     * extends to the end of this string. <p>
     * Examples:
     * <blockquote><pre>
     * "unhappy".substring(2) returns "happy"
     * "Harbison".substring(3) returns "bison"
     * "emptiness".substring(9) returns "" (an empty string)
     * </pre></blockquote>
     *
     * @param      beginIndex   the beginning index, inclusive.
     * @return     the specified substring.
     * @exception  IndexOutOfBoundsException  if
     *             {@code beginIndex} is negative or larger than the
     *             length of this {@code String} object.
     */
    public String substring(int beginIndex)
```